### PR TITLE
adding missing type property & fix behavior references in plugin

### DIFF
--- a/plugins/build.js
+++ b/plugins/build.js
@@ -425,8 +425,9 @@ function getEditorPluginInfoFromConfig(config) {
     domSideScripts: config.domSideScripts,
     fileDependencies: config.fileDependencies,
     icon: config.icon,
+    type: config.type
   };
-  //return "const PLUGIN_INFO = " + JSON.stringify(editorPluginInfo, null, 2);
+  //return "const BEHAVIOR_INFO = " + JSON.stringify(editorPluginInfo, null, 2);
   return `const PLUGIN_INFO = {
     ...${JSON.stringify(editorPluginInfo, null, 2)},
     properties: [

--- a/plugins/src/plugin.js
+++ b/plugins/src/plugin.js
@@ -102,8 +102,8 @@ Object.keys(PLUGIN_INFO.Acts).forEach((key) => {
 const addonTriggers = [];
 
 // extend script interface with plugin conditions
-Object.keys(BEHAVIOR_INFO.Cnds).forEach((key) => {
-  const ace = BEHAVIOR_INFO.Cnds[key];
+Object.keys(PLUGIN_INFO.Cnds).forEach((key) => {
+  const ace = PLUGIN_INFO.Cnds[key];
   if (!ace.autoScriptInterface || ace.isStatic || ace.isLooping) return;
   if (ace.isTrigger) {
     scriptInterface.prototype[camelCasify(key)] = function (callback, ...args) {
@@ -146,8 +146,8 @@ Object.keys(PLUGIN_INFO.Acts).forEach((key) => {
     else if (ace.handler) ace.handler.call(this, ...args);
   };
 });
-Object.keys(BEHAVIOR_INFO.Cnds).forEach((key) => {
-  const ace = BEHAVIOR_INFO.Cnds[key];
+Object.keys(PLUGIN_INFO.Cnds).forEach((key) => {
+  const ace = PLUGIN_INFO.Cnds[key];
   P_C.Cnds[camelCasify(key)] = function (...args) {
     if (ace.forward) return ace.forward(this).call(this, ...args);
     if (ace.handler) return ace.handler.call(this, ...args);


### PR DESCRIPTION
Added type property to PLUGIN_INFO, the type property is used in deriving the instance base class depending on if its a world/object/dom, without this type the addon fails to load because it cannot get the correct base class.

Also fixed a few more instances in the plugin config, where it is referencing BEHAVIOR_INFO 

with the changes above I was able to build a simple addon.