### PR TITLE
automatically generates plugin documentation in the README file.

### DIFF
--- a/plugins/.github/workflows/build_and_release.yml
+++ b/plugins/.github/workflows/build_and_release.yml
@@ -24,6 +24,23 @@ jobs:
         run: |
           npm ci
           npm run build
+          
+      - name: Auto Generate Documentation
+        run: |
+          npm run doc
+      
+      - name: Commit Documentation
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub Actions"
+          git add README.md
+          git commit -m "Update Readme.md"
+
+      - name: Push Documentation
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
 
       - name: Get last modified file
         id: getfile

--- a/plugins/doc.js
+++ b/plugins/doc.js
@@ -57,8 +57,10 @@ readme.push(
 readme.push(`## Examples Files`);
 const exampleFiles = fs.readdirSync(path.join(__dirname, "examples"));
 exampleFiles.forEach((file) => {
-  const fileName = file.split(".")[0];
-  readme.push(`- [${fileName}](./examples/${file})`);
+  if (file.endsWith(".c3p")) {
+    const fileName = file.split(".")[0];
+    readme.push(`- [${fileName}](./examples/${file})`);
+  }
 });
 
 

--- a/plugins/doc.js
+++ b/plugins/doc.js
@@ -23,6 +23,9 @@ if (config.addonUrl && config.addonUrl !== "") {
 if(config.githubUrl && config.githubUrl !== "") {
   readme.push(`Download Latest Version : [Version: ${config.version}](${config.githubUrl}/releases/latest) <br>`);
 }
+//add link to c3ide2-framework
+readme.push(`<sub>Made using [c3ide2-framework](https://github.com/ConstructFund/c3ide2-framework) </sub><br>`);
+readme.push(``);
 
 readme.push(`## Table of Contents`);
 readme.push(`- [Usage](#usage)`);

--- a/plugins/doc.js
+++ b/plugins/doc.js
@@ -1,0 +1,198 @@
+const fs = require("fs");
+const path = require("path");
+
+const camelCasedMap = new Map();
+
+function generateMDLinkFromText(text) {
+  return text.replace(/ /g, "-").toLowerCase();
+}
+
+const config = require("./src/pluginConfig.js");
+
+const readme = [];
+readme.push(`# ${config.name} <br>`);
+readme.push(`${config.description} <br>`);
+readme.push(``);
+readme.push(`Author: ${config.author} <br>`);
+if (config.website && config.website !== "" && config.website !== "https://www.construct.net") {
+  readme.push(`Website: ${config.website} <br>`)
+}
+if (config.addonUrl && config.addonUrl !== "") {
+  readme.push(`Addon Url: ${config.addonUrl} <br>`);
+}
+if(config.githubUrl && config.githubUrl !== "") {
+  readme.push(`Download Latest Version : [Version: ${config.version}](${config.githubUrl}/releases/latest) <br>`);
+}
+
+readme.push(`## Table of Contents`);
+readme.push(`- [Usage](#usage)`);
+readme.push(`- [Examples Files](#examples-files)`);
+readme.push(`- [Properties](#properties)`);
+readme.push(`- [Actions](#actions)`);
+readme.push(`- [Conditions](#conditions)`);
+readme.push(`- [Expressions](#expressions)`);
+
+
+readme.push(`## Usage`);
+readme.push(`To build the addon, run the following commands:`);
+readme.push(``);
+readme.push(`\`\`\``);
+readme.push(`npm i`);
+readme.push(`node ./build.js`);
+readme.push(`\`\`\``);
+readme.push(``);
+readme.push(`To run the dev server, run`);
+readme.push(``);
+readme.push(`\`\`\``);
+readme.push(`npm i`);
+readme.push(`node ./dev.js`);
+readme.push(`\`\`\``);
+readme.push(``);
+readme.push(`The build uses the pluginConfig file to generate everything else.`);
+readme.push(
+  `The main files you may want to look at would be instance.js and scriptInterface.js`
+);
+
+
+readme.push(`## Examples Files`);
+const exampleFiles = fs.readdirSync(path.join(__dirname, "examples"));
+exampleFiles.forEach((file) => {
+  const fileName = file.split(".")[0];
+  readme.push(`- [${fileName}](./examples/${file})`);
+});
+
+
+readme.push(`## Properties`);
+readme.push(`| Property Name | Description`);
+readme.push(`| --- | --- |`);
+
+config.properties.forEach((property) => {
+  readme.push(
+    `| [${property.name}](#${generateMDLinkFromText(property.name)}) | ${property.desc} |`
+  ); 
+});
+readme.push(`---`);
+
+config.properties.forEach((property) => {
+  readme.push(`### ${property.name}`);
+  readme.push(`**Description:** ${property.desc} </br>`);
+  readme.push(`**Type:** ${property.type}`);
+  if (property.type === "combo") {
+    readme.push(`**Options:**`);
+    property.options.items.forEach((item) => {
+      const key = Object.keys(item)[0];
+      readme.push(`- ${key}: ${item[key]}`);
+    });
+  } else if (property.type === "link") {
+    readme.push(`**Link Text:** ${property.linkText}`);
+  }
+});
+
+readme.push(`## Actions`);
+readme.push(`| Action | Description |`);
+readme.push(`| --- | --- |`);
+
+Object.keys(config.Acts).forEach((key) => {
+  const action = config.Acts[key];
+  readme.push(
+    `| [${action.listName}](#${generateMDLinkFromText(action.listName)}) | ${action.description} |`
+  );
+});
+readme.push(`---`);
+
+Object.keys(config.Acts).forEach((key) => {
+  const action = config.Acts[key];
+  readme.push(`### ${action.listName}`);
+  readme.push(`**Description:** ${action.description} </br>`);
+
+  if (action.isAsync) {
+    readme.push(`**Is Async:** ${action.isAsync} </br>`);
+  } 
+
+  if(action.params.length > 0){
+    readme.push(`#### Parameters:`);
+    // write parameters to indented table, with three columns (name, type, description)
+    readme.push(`| Name | Type | Description |`);
+    readme.push(`| --- | --- | --- |`);
+    action.params.forEach((param) => {
+      readme.push(
+        `| ${param.name} | ${param.type} | ${param.desc} |`
+      );
+    });
+  }
+});
+
+
+readme.push(`## Conditions`);
+readme.push(`| Condition | Description |`);
+readme.push(`| --- | --- |`);
+
+Object.keys(config.Cnds).forEach((key) => {
+  const condition = config.Cnds[key];
+  readme.push(
+    `| [${condition.listName}](#${generateMDLinkFromText(condition.listName)}) | ${condition.description} |`
+  );
+});
+readme.push(`---`);
+
+Object.keys(config.Cnds).forEach((key) => {
+  const condition = config.Cnds[key];
+  readme.push(`### ${condition.listName}`);
+  readme.push(`**Description:** ${condition.description} </br>`);
+  if (condition.isTrigger) {
+    readme.push(`**Is Trigger:** ${action.isTrigger} </br>`);
+  }
+  if(condition.islooping) {
+    readme.push(`**Is Looping:** ${action.islooping} </br>`);
+  }
+
+  if(condition.params.length > 0) {
+    readme.push(`#### Parameters:`);
+    // write parameters to indented table, with three columns (name, type, description)
+    readme.push(`| Name | Type | Description |`);
+    readme.push(`| --- | --- | --- |`);
+    condition.params.forEach((param) => {
+      readme.push(
+        `| ${param.name} | ${param.type} | ${param.desc} |`
+      );
+    });
+  }
+});
+
+readme.push(``);
+readme.push(`## Expressions`);
+readme.push(`| Expression | Description |`);
+readme.push(`| --- | --- |`);
+
+Object.keys(config.Exps).forEach((key) => {
+  const expression = config.Exps[key];
+  readme.push(
+    `| [${key}](#${generateMDLinkFromText(key)}) | ${expression.description} |`
+  );
+});
+readme.push(`---`);
+
+Object.keys(config.Exps).forEach((key) => {
+  const expression = config.Exps[key];
+  readme.push(`### ${key}`);
+  readme.push(`**Description:** ${expression.description} </br>`);
+  readme.push(`**Return Type:** ${expression.returnType} </br>`);
+  if(expression.isVariadicParam) {
+    readme.push(`**Is Variadic Param:** ${expression.isVariadicParam} </br>`);
+  }
+  if(expression.params.length > 0) {
+    readme.push(`#### Parameters:`);
+    // write parameters to indented table, with three columns (name, type, description)
+    readme.push(`| Name | Type | Description |`);
+    readme.push(`| --- | --- | --- |`);
+    expression.params.forEach((param) => {
+      readme.push(
+        `| ${param.name} | ${param.type} | ${param.desc} |`
+      );
+    });
+  }
+});
+
+
+fs.writeFileSync(path.join(__dirname, "README.md"), readme.join("\n"));
+

--- a/plugins/examples/README.md
+++ b/plugins/examples/README.md
@@ -1,0 +1,1 @@
+Put C3P File here, All files here will be included in generated documentation! 

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -10,7 +10,8 @@
   "version": "1.0.0",
   "scripts": {
     "build": "node build.js",
-    "dev": "node dev.js"
+    "dev": "node dev.js",
+    "doc": "node doc.js"
   },
   "repository": {
     "type": "git",

--- a/plugins/src/pluginConfig.js
+++ b/plugins/src/pluginConfig.js
@@ -19,9 +19,10 @@ module.exports = {
   website: "https://www.construct.net",
   documentation: "https://www.construct.net",
   description: "Description",
+  // addonUrl: "https://www.construct.net/en/make-games/addons/####/XXXX", // displayed in auto-generated docs
+  // githubUrl: "https://github.com/skymen/XXXX", // displays latest release version in auto-generated docs
   // icon: "icon.svg", // defaults to "icon.svg" if omitted
-  // world, object, dom
-  type: "object",
+  type: "object",   // world, object, dom
   domSideScripts: [
     // "domSide.js", // no need to include "c3runtime/" prefix
   ],


### PR DESCRIPTION
Generates plugin documentation as part of the check-in process to main. github action will modify the README and push a new version.

Added 2 properties to pluginConfig.js that will drive displaying link to the construct addon page and the latest release on github.
Added an example folder in the root, that will be used in displaying links to example file in readme. 

For example of generated documentation please see...
[Sample Plugin](https://github.com/armandoalonso/rng)


** will add support for behaviors and effects in later check-ins