### PR TITLE
fixing plugin properties being read as null

### DIFF
--- a/plugins/src/editor.js
+++ b/plugins/src/editor.js
@@ -59,7 +59,7 @@ SDK.Plugins[PLUGIN_INFO.id] = class extends SDK.IPluginBase {
     this._info.SetProperties(
       (PLUGIN_INFO.properties || []).map(
         (prop) =>
-          new SDK.PluginProperty(prop.type, prop.id, prop.value, prop.options)
+          new SDK.PluginProperty(prop.type, prop.id, prop.options)
       )
     );
     SDK.Lang.PopContext(); // .properties


### PR DESCRIPTION
fixing plugin properties being read as null, value does not exist in pluginConfig schema, and c3 only takes a value OR and options object (which can contain initial value), not both.

