### PR TITLE
Add basic validation logic to plugin & behaviors

### DIFF
--- a/behaviors/package.json
+++ b/behaviors/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "node build.js",
     "dev": "node dev.js",
-    "doc": "node doc.js"
+    "doc": "node doc.js",
+    "validate": "node validate.js" 
   },
   "repository": {
     "type": "git",

--- a/behaviors/validate.js
+++ b/behaviors/validate.js
@@ -1,0 +1,71 @@
+const fs = require("fs");
+const path = require("path");
+
+const config = require("./src/behaviorConfig.js");
+const { exit } = require("process");
+
+function validateDisplayText(name, obj) {
+    // check if obj has displayText property
+    if (obj.hasOwnProperty("displayText")) {
+        const paramCount = obj.params.length;
+        // use regex to find the number of {/d} in displayText
+        const regex = /{\d}/g;
+        const matches = obj.displayText.match(regex);
+        const matchCount = matches ? matches.length : 0;
+        // check if the number of {/d} matches the number of params
+        if (paramCount !== matchCount) {
+            console.log(
+                `Error: ${name} has ${matchCount} {x} in displayText but has ${paramCount} params`
+            );
+            return false; // validation failed
+        }
+    }
+    return true; // validation passed
+} 
+
+
+const validationPipeline = [
+    validateDisplayText
+];
+
+function validateBehavior(behaviorConfig) {
+    //assume file is valid
+    const validations = [];
+
+    // iterate over all the actions
+    Object.keys(behaviorConfig.Acts).forEach((key) => {
+        const action = behaviorConfig.Acts[key];
+        validationPipeline.forEach((validationFunction) => {
+            validations.push(validationFunction(key, action));
+        });
+    });
+
+    // iterate over all the conditions
+    Object.keys(behaviorConfig.Cnds).forEach((key) => {
+        const condition = behaviorConfig.Cnds[key];
+        validationPipeline.forEach((validationFunction) => {
+            validations.push(validationFunction(key, condition));
+        });
+    });
+
+    // iterate over all the expressions
+    Object.keys(behaviorConfig.Exps).forEach((key) => {
+        const expression = behaviorConfig.Exps[key];
+        validationPipeline.forEach((validationFunction) => {
+            validations.push(validationFunction(key, expression));
+        });
+    });
+
+    // check if any validation failed
+    return validations.every((validation) => validation);
+}
+
+
+// check if the file is valid
+if (validateBehavior(config)) {
+    console.info("Validation Passed");
+    exit(0);
+} else {
+    console.error("Validation Failed");
+    exit(1);
+}

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "build": "node build.js",
     "dev": "node dev.js",
-    "doc": "node doc.js"
+    "doc": "node doc.js",
+    "validate": "node validate.js" 
   },
   "repository": {
     "type": "git",

--- a/plugins/validate.js
+++ b/plugins/validate.js
@@ -1,0 +1,71 @@
+const fs = require("fs");
+const path = require("path");
+
+const config = require("./src/pluginConfig.js");
+const { exit } = require("process");
+
+function validateDisplayText(name, obj) {
+    // check if obj has displayText property
+    if (obj.hasOwnProperty("displayText")) {
+        const paramCount = obj.params.length;
+        // use regex to find the number of {/d} in displayText
+        const regex = /{\d}/g;
+        const matches = obj.displayText.match(regex);
+        const matchCount = matches ? matches.length : 0;
+        // check if the number of {/d} matches the number of params
+        if (paramCount !== matchCount) {
+            console.log(
+                `Error: ${name} has ${matchCount} {x} in displayText but has ${paramCount} params`
+            );
+            return false; // validation failed
+        }
+    }
+    return true; // validation passed
+} 
+
+
+const validationPipeline = [
+    validateDisplayText
+];
+
+function valiatePlugin(pluginConfig) {
+    //assume file is valid
+    const validations = [];
+
+    // iterate over all the actions
+    Object.keys(pluginConfig.Acts).forEach((key) => {
+        const action = pluginConfig.Acts[key];
+        validationPipeline.forEach((validationFunction) => {
+            validations.push(validationFunction(key, action));
+        });
+    });
+
+    // iterate over all the conditions
+    Object.keys(pluginConfig.Cnds).forEach((key) => {
+        const condition = pluginConfig.Cnds[key];
+        validationPipeline.forEach((validationFunction) => {
+            validations.push(validationFunction(key, condition));
+        });
+    });
+
+    // iterate over all the expressions
+    Object.keys(pluginConfig.Exps).forEach((key) => {
+        const expression = pluginConfig.Exps[key];
+        validationPipeline.forEach((validationFunction) => {
+            validations.push(validationFunction(key, expression));
+        });
+    });
+
+    // check if any validation failed
+    return validations.every((validation) => validation);
+}
+
+
+// check if the file is valid
+if (valiatePlugin(config)) {
+    console.info("Validation Passed");
+    exit(0);
+} else {
+    console.error("Validation Failed");
+    exit(1);
+}


### PR DESCRIPTION
Adding simple validation pipeline for actions/conditions/expressions

Validations currently defined as function that takes in an object, and returns true or false (weather the validation passes or fails)

Every ace object defined in config will be passed to every validation function defined the pipeline (this object also has the potential to be constructed dynamically, so only a subset of all validation are run)

the only validation logic that was added was verifying display text placeholder count == param count. this throws exception in construct so catching it early should save a few minute's reloading code.

**Action items;**
- integrate validation in github actions pipelines ? should probably be another workflow that run on every branch.
- integrate running validation.js during local build (currently running validation is manual process ...) 
ie `node .\validation.js`
